### PR TITLE
Add inline disable comments for ZemDomu

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ the Settings UI or edit `settings.json` directly:
 - `zemdomu.crossComponentAnalysis` – analyze JSX components across files
 - `zemdomu.rules.*` – enable or disable individual semantic rules
 
+### Inline Rule Controls
+
+You can selectively disable ZemDomu using special comments:
+
+- `<!-- zemdomu-disable-next -->` – skip linting for the next element
+- `<!-- zemdomu-disable -->` – start a block where linting is disabled
+- `<!-- zemdomu-enable -->` – re-enable linting after a disabled block
+
+For JSX/TSX files use the JSX comment syntax, e.g. `{/* zemdomu-disable */}`.
+
 ---
 
 ## 🛠 Development

--- a/tests/inline-disable.test.js
+++ b/tests/inline-disable.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const { lintHtml } = require('../out/linter');
+
+const html = '<!-- zemdomu-disable-next --><img />';
+const res = lintHtml(html, false);
+assert.strictEqual(res.length, 0, 'Expected no warnings for disable-next');
+
+const block = '<!-- zemdomu-disable --><img /><!-- zemdomu-enable -->';
+const res2 = lintHtml(block, false);
+assert.strictEqual(res2.length, 0, 'Expected no warnings for disable block');
+console.log('Inline disable tests passed');


### PR DESCRIPTION
## Summary
- allow disabling/enabling blocks of markup with `zemdomu-disable` and `zemdomu-enable`
- document inline rule controls
- test inline disabling

## Testing
- `npm run compile`
- `node tests/linter-labels.test.js && node tests/inline-disable.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684864216d88833196cfbbdedd8d78e6