### PR TITLE
Add configurable severity levels for linter rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,66 @@
           "type": "boolean",
           "default": true,
           "description": "Warn when an <a> tag is missing a non-empty href attribute."
+        },
+        "zemdomu.severity.requireSectionHeading": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the requireSectionHeading rule."
+        },
+        "zemdomu.severity.enforceHeadingOrder": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the enforceHeadingOrder rule."
+        },
+        "zemdomu.severity.singleH1": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the singleH1 rule."
+        },
+        "zemdomu.severity.requireAltText": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the requireAltText rule."
+        },
+        "zemdomu.severity.requireLabelForFormControls": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the requireLabelForFormControls rule."
+        },
+        "zemdomu.severity.enforceListNesting": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the enforceListNesting rule."
+        },
+        "zemdomu.severity.requireLinkText": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the requireLinkText rule."
+        },
+        "zemdomu.severity.requireTableCaption": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the requireTableCaption rule."
+        },
+        "zemdomu.severity.preventEmptyInlineTags": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the preventEmptyInlineTags rule."
+        },
+        "zemdomu.severity.requireHrefOnAnchors": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the requireHrefOnAnchors rule."
         }
       }
     }

--- a/src/component-analyzer.ts
+++ b/src/component-analyzer.ts
@@ -153,7 +153,8 @@ export class ComponentAnalyzer {
             {
               line: heading.line,
               column: heading.column,
-              message: `Heading level skipped: <h${heading.level}> after <h${lastHeadingLevel}>`
+              message: `Heading level skipped: <h${heading.level}> after <h${lastHeadingLevel}>`,
+              rule: 'enforceHeadingOrder'
             }
           ]);
         }
@@ -165,7 +166,7 @@ export class ComponentAnalyzer {
     if (this.options.rules.singleH1) {
       const h1Results: LintResult[] = componentDef.headings
         .filter(h => h.level === 1)
-        .map(h => ({ line: h.line, column: h.column, message: '<h1>' }));
+        .map(h => ({ line: h.line, column: h.column, message: '<h1>', rule: 'singleH1' }));
       if (h1Results.length > 0) {
         componentDef.issues.set('singleH1', h1Results);
       }
@@ -208,7 +209,7 @@ export class ComponentAnalyzer {
 
   registerComponent(component: ComponentDefinition, issues: LintResult[]): void {
     for (const issue of issues) {
-      const rule = this.getRuleType(issue.message);
+      const rule = issue.rule || this.getRuleType(issue.message);
       if (!component.issues.has(rule)) component.issues.set(rule, []);
       component.issues.get(rule)!.push(issue);
     }
@@ -255,15 +256,17 @@ export class ComponentAnalyzer {
               filePath: entry.filePath,
               line: location.line,
               column: location.column,
-              message: `Multiple <h1> tags: component '${comp.name}' brings an extra <h1>. Use a lower-level heading.`
+              message: `Multiple <h1> tags: component '${comp.name}' brings an extra <h1>. Use a lower-level heading.`,
+              rule: 'singleH1'
             });
           } else {
             const issue = comp.issues.get('singleH1')![0];
-            results.push({ 
-              filePath: comp.filePath, 
-              line: issue.line, 
+            results.push({
+              filePath: comp.filePath,
+              line: issue.line,
               column: issue.column,
-              message: `Multiple <h1> across components - consider using lower-level headings.`
+              message: `Multiple <h1> across components - consider using lower-level headings.`,
+              rule: 'singleH1'
             });
           }
         }
@@ -322,7 +325,8 @@ export class ComponentAnalyzer {
           filePath: heading.usageLocation?.filePath || heading.heading.filePath,
           line: heading.usageLocation?.line || heading.heading.line,
           column: heading.usageLocation?.column || heading.heading.column,
-          message: `Cross-component heading level skipped: <h${heading.heading.level}> after <h${lastLevel}>`
+          message: `Cross-component heading level skipped: <h${heading.heading.level}> after <h${lastLevel}>`,
+          rule: 'enforceHeadingOrder'
         });
       }
       lastLevel = heading.heading.level;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,6 +88,12 @@ requireSectionHeading: config.get('rules.requireSectionHeading', true),
     };
   }
 
+  function getRuleSeverity(rule: string): vscode.DiagnosticSeverity {
+    const config = vscode.workspace.getConfiguration('zemdomu');
+    const setting = config.get(`severity.${rule}`, 'warning') as string;
+    return setting === 'error' ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Warning;
+  }
+
   async function lintDocument(uri: vscode.Uri, xmlMode: boolean) {
     try {
       const text = (await vscode.workspace.openTextDocument(uri)).getText();
@@ -108,7 +114,11 @@ requireSectionHeading: config.get('rules.requireSectionHeading', true),
       const diags = results.map(r => {
         const start = new vscode.Position(r.line, r.column);
         const end = new vscode.Position(r.line, r.column + 1);
-        return new vscode.Diagnostic(new vscode.Range(start, end), r.message, vscode.DiagnosticSeverity.Warning);
+        return new vscode.Diagnostic(
+          new vscode.Range(start, end),
+          r.message,
+          getRuleSeverity(r.rule)
+        );
       });
       diagnostics.set(uri, diags);
     } catch (e) {
@@ -147,7 +157,7 @@ requireSectionHeading: config.get('rules.requireSectionHeading', true),
       const diags = results.map(r => {
         const start = new vscode.Position(r.line, r.column);
         const end = new vscode.Position(r.line, r.column + 1);
-        return new vscode.Diagnostic(new vscode.Range(start, end), r.message, vscode.DiagnosticSeverity.Warning);
+        return new vscode.Diagnostic(new vscode.Range(start, end), r.message, getRuleSeverity(r.rule));
       });
       diagnostics.set(uri, diags);
     }));
@@ -182,9 +192,9 @@ requireSectionHeading: config.get('rules.requireSectionHeading', true),
           const start = new vscode.Position(r.line, r.column);
           const end = new vscode.Position(r.line, r.column + 1);
           return new vscode.Diagnostic(
-            new vscode.Range(start, end), 
+            new vscode.Range(start, end),
             r.message,
-            vscode.DiagnosticSeverity.Warning
+            getRuleSeverity(r.rule)
           );
         });
         

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -8,6 +8,8 @@ export interface LintResult {
   line: number;
   column: number;
   message: string;
+  /** Identifier for the rule that produced this result */
+  rule: string;
   filePath?: string;
 }
 
@@ -110,22 +112,22 @@ function lintHtmlString(html: string, options: LinterOptions): LintResult[] {
         const id = attrs.id;
         const aria = attrs['aria-label'];
         if (!aria || !aria.trim()) {
-          if (!id) results.push({ ...pos, message: 'Form control missing id or aria-label' });
-          else if (!labels.has(id)) results.push({ ...pos, message: `Form control with id="${id}" missing <label for=\"${id}\">` });
+          if (!id) results.push({ ...pos, message: 'Form control missing id or aria-label', rule: 'requireLabelForFormControls' });
+          else if (!labels.has(id)) results.push({ ...pos, message: `Form control with id="${id}" missing <label for=\"${id}\">`, rule: 'requireLabelForFormControls' });
         }
       }
       
       // only one h1
       if (options.rules.singleH1 && tag === 'h1') {
         h1Count++;
-        if (h1Count > 1) results.push({ ...pos, message: 'Only one <h1> allowed per document' });
+        if (h1Count > 1) results.push({ ...pos, message: 'Only one <h1> allowed per document', rule: 'singleH1' });
       }
       
       // heading order
       if (options.rules.enforceHeadingOrder && /^h[1-6]$/.test(tag)) {
         const lvl = parseInt(tag.charAt(1), 10);
         if (lastHeadingLevel && lvl > lastHeadingLevel + 1) {
-          results.push({ ...pos, message: `Heading level skipped: <${tag}> after <h${lastHeadingLevel}>` });
+          results.push({ ...pos, message: `Heading level skipped: <${tag}> after <h${lastHeadingLevel}>`, rule: 'enforceHeadingOrder' });
         }
         lastHeadingLevel = lvl;
         if (sectionStack.length) sectionStack[sectionStack.length - 1].foundHeading = true;
@@ -134,14 +136,14 @@ function lintHtmlString(html: string, options: LinterOptions): LintResult[] {
       // img alt
       if (options.rules.requireAltText && tag === 'img') {
         const alt = attrs.alt;
-        if (!alt || !alt.trim()) results.push({ ...pos, message: '<img> tag missing non-empty alt attribute' });
+        if (!alt || !alt.trim()) results.push({ ...pos, message: '<img> tag missing non-empty alt attribute', rule: 'requireAltText' });
       }
       
       // li nesting
       if (options.rules.enforceListNesting && tag === 'li') {
         const parent = tagStack[tagStack.length - 2];
         if (!parent || !['ul','ol'].includes(parent.tag)) {
-          results.push({ ...pos, message: '<li> must be inside a <ul> or <ol>' });
+          results.push({ ...pos, message: '<li> must be inside a <ul> or <ol>', rule: 'enforceListNesting' });
         }
       }
       
@@ -151,7 +153,7 @@ function lintHtmlString(html: string, options: LinterOptions): LintResult[] {
         
         if (options.rules.requireHrefOnAnchors) {
           const href = attrs.href;
-          if (!href || !href.trim()) results.push({ ...pos, message: '<a> tag missing non-empty href attribute' });
+          if (!href || !href.trim()) results.push({ ...pos, message: '<a> tag missing non-empty href attribute', rule: 'requireHrefOnAnchors' });
         }
       }
       
@@ -173,22 +175,22 @@ function lintHtmlString(html: string, options: LinterOptions): LintResult[] {
       
       if (options.rules.preventEmptyInlineTags && inlineTags.has(tag)) {
         const e = emptyStack.pop();
-        if (e && !e.foundText) results.push({ line: e.line, column: e.column, message: `<${tag}> tag should not be empty` });
+        if (e && !e.foundText) results.push({ line: e.line, column: e.column, message: `<${tag}> tag should not be empty`, rule: 'preventEmptyInlineTags' });
       }
       
       if (options.rules.requireLinkText && tag === 'a') {
         const a = anchorStack.pop();
-        if (a && !a.foundText) results.push({ line: a.line, column: a.column, message: '<a> tag missing link text' });
+        if (a && !a.foundText) results.push({ line: a.line, column: a.column, message: '<a> tag missing link text', rule: 'requireLinkText' });
       }
       
       if (options.rules.requireSectionHeading && tag === 'section') {
         const s = sectionStack.pop();
-        if (s && !s.foundHeading) results.push({ line: s.line, column: s.column, message: '<section> missing heading (<h1>-<h6>)' });
+        if (s && !s.foundHeading) results.push({ line: s.line, column: s.column, message: '<section> missing heading (<h1>-<h6>)', rule: 'requireSectionHeading' });
       }
       
       if (options.rules.requireTableCaption && tag === 'table') {
         const t = tableStack.pop();
-        if (t && !t.foundCaption) results.push({ line: t.line, column: t.column, message: '<table> missing <caption>' });
+        if (t && !t.foundCaption) results.push({ line: t.line, column: t.column, message: '<table> missing <caption>', rule: 'requireTableCaption' });
       }
     }
   }, { decodeEntities: true, xmlMode: false, recognizeSelfClosing: true });
@@ -271,21 +273,21 @@ function lintJsx(code: string, options: LinterOptions): LintResult[] {
               }
             });
             if (!ariaVal || !ariaVal.trim()) {
-              if (!idVal) results.push({ ...pos, message: 'Form control missing id or aria-label' });
-              else if (!labels.has(idVal)) results.push({ ...pos, message: `Form control with id="${idVal}" missing <label for=\"${idVal}\">` });
+              if (!idVal) results.push({ ...pos, message: 'Form control missing id or aria-label', rule: 'requireLabelForFormControls' });
+              else if (!labels.has(idVal)) results.push({ ...pos, message: `Form control with id="${idVal}" missing <label for=\"${idVal}\">`, rule: 'requireLabelForFormControls' });
             }
           }
           
           // only one h1
           if (options.rules.singleH1 && tag === 'h1') { 
             h1Count++; 
-            if (h1Count > 1) results.push({ ...pos, message: 'Only one <h1> allowed per document' }); 
+            if (h1Count > 1) results.push({ ...pos, message: 'Only one <h1> allowed per document', rule: 'singleH1' });
           }
           
           // heading order
           if (options.rules.enforceHeadingOrder && /^h[1-6]$/.test(tag)) {
             const lvl = parseInt(tag.charAt(1), 10);
-            if (lastHeadingLevel && lvl > lastHeadingLevel + 1) results.push({ ...pos, message: `Heading level skipped: <${tag}> after <h${lastHeadingLevel}>` });
+            if (lastHeadingLevel && lvl > lastHeadingLevel + 1) results.push({ ...pos, message: `Heading level skipped: <${tag}> after <h${lastHeadingLevel}>`, rule: 'enforceHeadingOrder' });
             lastHeadingLevel = lvl;
             if (sectionStack.length) sectionStack[sectionStack.length - 1].foundHeading = true;
           }
@@ -296,7 +298,7 @@ function lintJsx(code: string, options: LinterOptions): LintResult[] {
               t.isJSXAttribute(attr) && t.isJSXIdentifier(attr.name) && attr.name.name === 'alt' &&
               t.isStringLiteral(attr.value) && attr.value.value.trim() !== ''
             );
-            if (!hasAlt) results.push({ ...pos, message: '<img> missing non-empty alt attribute' });
+            if (!hasAlt) results.push({ ...pos, message: '<img> missing non-empty alt attribute', rule: 'requireAltText' });
           }
           
           // li nesting
@@ -306,7 +308,7 @@ function lintJsx(code: string, options: LinterOptions): LintResult[] {
               const p = parent.openingElement.name;
               if (t.isJSXIdentifier(p)) {
                 const pTag = p.name.toLowerCase();
-                if (!['ul', 'ol'].includes(pTag)) results.push({ ...pos, message: '<li> must be inside a <ul> or <ol>' });
+                if (!['ul', 'ol'].includes(pTag)) results.push({ ...pos, message: '<li> must be inside a <ul> or <ol>', rule: 'enforceListNesting' });
               }
             }
           }
@@ -323,7 +325,7 @@ function lintJsx(code: string, options: LinterOptions): LintResult[] {
               ) as t.JSXAttribute | undefined;
               
               if (!hrefVal || !t.isStringLiteral(hrefVal.value) || !hrefVal.value.value.trim()) {
-                results.push({ ...pos, message: '<a> tag missing non-empty href attribute' });
+                results.push({ ...pos, message: '<a> tag missing non-empty href attribute', rule: 'requireHrefOnAnchors' });
               }
             }
           }
@@ -350,24 +352,24 @@ function lintJsx(code: string, options: LinterOptions): LintResult[] {
           const pos = { line: opening.loc.start.line - 1, column: opening.loc.start.column };
           
           if (options.rules.preventEmptyInlineTags && ['strong','em','b','i','u','small','mark','del','ins'].includes(tag)) {
-            const e = emptyStack.pop(); 
-            if (e && !e.foundText) results.push({ ...e, message: `<${tag}> tag should not be empty` });
+            const e = emptyStack.pop();
+            if (e && !e.foundText) results.push({ ...e, message: `<${tag}> tag should not be empty`, rule: 'preventEmptyInlineTags' });
           }
           
-          if (options.rules.requireLinkText && tag === 'a') { 
-            const a = anchorStack.pop(); 
-            if (a && !a.foundText) results.push({ ...a, message: '<a> tag missing link text' }); 
+          if (options.rules.requireLinkText && tag === 'a') {
+            const a = anchorStack.pop();
+            if (a && !a.foundText) results.push({ ...a, message: '<a> tag missing link text', rule: 'requireLinkText' });
           }
           
-          if (options.rules.requireSectionHeading && tag === 'section') { 
-            const s = sectionStack.pop(); 
-            if (s && !s.foundHeading) results.push({ ...s, message: '<section> missing heading (<h1>-<h6>)' }); 
+          if (options.rules.requireSectionHeading && tag === 'section') {
+            const s = sectionStack.pop();
+            if (s && !s.foundHeading) results.push({ ...s, message: '<section> missing heading (<h1>-<h6>)', rule: 'requireSectionHeading' });
           }
           
           if (options.rules.requireTableCaption && tag === 'table') {
             const tableEntry = tableStack.pop();
             if (tableEntry && !tableEntry.foundCaption) {
-              results.push({ ...tableEntry, message: '<table> missing <caption>' });
+              results.push({ ...tableEntry, message: '<table> missing <caption>', rule: 'requireTableCaption' });
             }
           }
         }
@@ -401,7 +403,8 @@ function lintJsx(code: string, options: LinterOptions): LintResult[] {
     return [{
       line: 0,
       column: 0,
-      message: `Error parsing JSX/TSX: ${e instanceof Error ? e.message : String(e)}`
+      message: `Error parsing JSX/TSX: ${e instanceof Error ? e.message : String(e)}`,
+      rule: 'parseError'
     }];
   }
 }


### PR DESCRIPTION
## Summary
- add `rule` field to `LintResult`
- update linter to include rule identifiers
- allow configuration of rule severities in package.json
- create helper in extension to read severity and apply to diagnostics
- include rule data in component analyzer

## Testing
- `npm run compile`
- `node tests/inline-disable.test.js && node tests/linter-labels.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684868190c3c8331b609830efcc3bf0a