### PR TITLE
Add additional HTML semantics checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
 - 🟢 Warns when `<li>` is not inside `<ul>` or `<ol>`
 - 🔵 Ensures correct heading order (`<h1> → <h2> → <h3>`…)
 - 🟠 Flags missing `alt` attributes on `<img>`
+- 🟣 Ensures `<button>` elements have accessible text
+- 🟤 Requires `<iframe>` tags to include a `title`
+- 🔶 Enforces `lang` on the `<html>` element
+- 🔷 Checks `<input type="image">` for `alt` text
 - 🔴 Detects form fields missing `aria-label` or `<label for="">`
 - ⚠️ Highlights empty `<strong>`, `<em>`, and similar tags
 - 📛 Verifies `<a>` tags have both `href` and link text

--- a/package.json
+++ b/package.json
@@ -105,6 +105,26 @@
           "default": true,
           "description": "Warn when an <a> tag is missing a non-empty href attribute."
         },
+        "zemdomu.rules.requireButtonText": {
+          "type": "boolean",
+          "default": true,
+          "description": "Warn when a <button> lacks accessible text or aria-label."
+        },
+        "zemdomu.rules.requireIframeTitle": {
+          "type": "boolean",
+          "default": true,
+          "description": "Warn when an <iframe> is missing a title attribute."
+        },
+        "zemdomu.rules.requireHtmlLang": {
+          "type": "boolean",
+          "default": true,
+          "description": "Warn when the <html> tag lacks a lang attribute."
+        },
+        "zemdomu.rules.requireImageInputAlt": {
+          "type": "boolean",
+          "default": true,
+          "description": "Warn when <input type=\"image\"> is missing alt text."
+        },
         "zemdomu.severity.requireSectionHeading": {
           "type": "string",
           "enum": ["warning", "error"],
@@ -164,6 +184,30 @@
           "enum": ["warning", "error"],
           "default": "warning",
           "description": "Severity for the requireHrefOnAnchors rule."
+        },
+        "zemdomu.severity.requireButtonText": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the requireButtonText rule."
+        },
+        "zemdomu.severity.requireIframeTitle": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the requireIframeTitle rule."
+        },
+        "zemdomu.severity.requireHtmlLang": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the requireHtmlLang rule."
+        },
+        "zemdomu.severity.requireImageInputAlt": {
+          "type": "string",
+          "enum": ["warning", "error"],
+          "default": "warning",
+          "description": "Severity for the requireImageInputAlt rule."
         }
       }
     }

--- a/src/component-analyzer.ts
+++ b/src/component-analyzer.ts
@@ -221,6 +221,10 @@ export class ComponentAnalyzer {
     if (msg.includes('Heading level')) return 'enforceHeadingOrder';
     if (msg.includes('<section>')) return 'requireSectionHeading';
     if (msg.includes('<img>')) return 'requireAltText';
+    if (msg.includes('missing title attribute')) return 'requireIframeTitle';
+    if (msg.includes('missing alt attribute') && msg.includes('input type="image"')) return 'requireImageInputAlt';
+    if (msg.includes('<html>')) return 'requireHtmlLang';
+    if (msg.includes('<button>')) return 'requireButtonText';
     if (msg.includes('Form control')) return 'requireLabelForFormControls';
     if (msg.includes('<li>')) return 'enforceListNesting';
     if (msg.includes('<a>')) return msg.includes('href') ? 'requireHrefOnAnchors' : 'requireLinkText';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,7 +82,11 @@ requireSectionHeading: config.get('rules.requireSectionHeading', true),
         requireLinkText: config.get('rules.requireLinkText', true),
         requireTableCaption: config.get('rules.requireTableCaption', true),
         preventEmptyInlineTags: config.get('rules.preventEmptyInlineTags', true),
-        requireHrefOnAnchors: config.get('rules.requireHrefOnAnchors', true)
+        requireHrefOnAnchors: config.get('rules.requireHrefOnAnchors', true),
+        requireButtonText: config.get('rules.requireButtonText', true),
+        requireIframeTitle: config.get('rules.requireIframeTitle', true),
+        requireHtmlLang: config.get('rules.requireHtmlLang', true),
+        requireImageInputAlt: config.get('rules.requireImageInputAlt', true)
       },
       crossComponentAnalysis: config.get('crossComponentAnalysis', true)
     };


### PR DESCRIPTION
## Summary
- expand `LinterOptions` with rules for buttons, iframes, html lang, and image inputs
- implement new semantic checks in the linter
- expose the new rules in the VS Code extension
- document the new rules in the README
- update configuration schema with default settings and severities

## Testing
- `npm run compile`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68486ba3cb98833187f7194e91747a55