### PR TITLE
Add VS Code tasks and publish helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ out/
 Thumbs.db
 
 # Dev/editor files
-.vscode/
+/.vscode/*
+!/.vscode/tasks.json
 yarn.lock

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "npm install",
+      "type": "shell",
+      "command": "npm install",
+      "group": "build"
+    },
+    {
+      "label": "npm compile",
+      "type": "shell",
+      "command": "npm run compile",
+      "group": "build"
+    },
+    {
+      "label": "npm package",
+      "type": "shell",
+      "command": "npm run package",
+      "group": "build"
+    },
+    {
+      "label": "npm publish extension",
+      "type": "shell",
+      "command": "npm install && npm run compile && npm run package",
+      "group": { "kind": "build", "isDefault": true }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -87,8 +87,15 @@ For JSX/TSX files use the JSX comment syntax, e.g. `{/* zemdomu-disable */}`.
 ## 🛠 Development
 
 ```bash
+npm run publish-all
+```
+
+Individual steps if you prefer to run them separately:
+
+```bash
 npm install
 npm run compile
+npm run package
 ```
 
 ## 📄 License

--- a/package.json
+++ b/package.json
@@ -216,7 +216,8 @@
     "compile": "tsc -p ./tsconfig.json",
     "watch": "tsc -w",
     "package": "vsce package",
-    "test": "echo 'No tests'"
+    "test": "echo 'No tests'",
+    "publish-all": "npm install && npm run compile && npm run package"
   },
   "devDependencies": {
     "@types/babel__traverse": "^7.20.7",


### PR DESCRIPTION
## Summary
- allow tracking `.vscode/tasks.json`
- add predefined VS Code tasks for install, compile, package, and publish
- add `publish-all` npm script that installs deps, compiles, then packages
- document new workflow in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684871538b1083318b745d17cc433e61