### PR TITLE
Add tests and bundle size tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ You can selectively disable ZemDomu using special comments:
 
 For JSX/TSX files use the JSX comment syntax, e.g. `{/* zemdomu-disable */}`.
 
+## Development
+
+Run the test suite to compile the extension, bundle it and track the bundle size:
+
+```bash
+npm test
+```
+
+The `package-size.test.js` script prints the size of `dist/extension.js` so you can monitor changes over time.
+
 ---
 
 MIT © 2025 Zacharias Eryd Berlin

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "watch": "tsc -w",
     "bundle": "esbuild out/extension.js --bundle --platform=node --minify --external:vscode --outfile=dist/extension.js",
     "package": "vsce package",
-    "test": "echo 'No tests'",
+    "test": "npm run compile && npm run bundle && node tests/inline-disable.test.js && node tests/linter-labels.test.js && node tests/unique-ids.test.js && node tests/package-size.test.js",
     "publish-all": "npm install && npm run compile && npm run bundle && npm run package"
   },
   "devDependencies": {

--- a/tests/inline-disable.test.js
+++ b/tests/inline-disable.test.js
@@ -1,11 +1,13 @@
 const assert = require('assert');
 const { lintHtml } = require('../out/linter');
 
+const options = { crossComponentAnalysis: false, rules: { requireAltText: true, requireMain: false } };
+
 const html = '<!-- zemdomu-disable-next --><img />';
-const res = lintHtml(html, false);
+const res = lintHtml(html, false, options);
 assert.strictEqual(res.length, 0, 'Expected no warnings for disable-next');
 
 const block = '<!-- zemdomu-disable --><img /><!-- zemdomu-enable -->';
-const res2 = lintHtml(block, false);
+const res2 = lintHtml(block, false, options);
 assert.strictEqual(res2.length, 0, 'Expected no warnings for disable block');
 console.log('Inline disable tests passed');

--- a/tests/linter-labels.test.js
+++ b/tests/linter-labels.test.js
@@ -1,8 +1,9 @@
 const assert = require('assert');
 const { lintHtml } = require('../out/linter');
 
-const jsx = `<label htmlFor="name">Name</label><input id="name" />`;
-const results = lintHtml(jsx, true);
+const options = { crossComponentAnalysis: false, rules: { requireMain: false } };
+const jsx = '<div><label htmlFor="name">Name</label><input id="name" /></div>';
+const results = lintHtml(jsx, true, options);
 const hasLabelWarning = results.some(r => r.message.includes('Form control'));
 assert.strictEqual(hasLabelWarning, false, 'Expected no Form control warning');
-console.log('All tests passed');
+console.log('Label tests passed');

--- a/tests/package-size.test.js
+++ b/tests/package-size.test.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+
+const bundlePath = path.join(__dirname, '..', 'dist', 'extension.js');
+if (!fs.existsSync(bundlePath)) {
+  throw new Error('Bundle not found. Run `npm run bundle` first.');
+}
+const bytes = fs.statSync(bundlePath).size;
+const kb = (bytes / 1024).toFixed(2);
+console.log(`Bundle size: ${kb} KB`);

--- a/tests/unique-ids.test.js
+++ b/tests/unique-ids.test.js
@@ -1,7 +1,8 @@
 const assert = require('assert');
 const { lintHtml } = require('../out/linter');
 
+const options = { crossComponentAnalysis: false, rules: { uniqueIds: true, requireMain: false } };
 const html = '<div id="dup"></div><span id="dup"></span>';
-const res = lintHtml(html, false);
+const res = lintHtml(html, false, options);
 assert.ok(res.some(r => r.rule === 'uniqueIds'), 'Expected duplicate id warning');
 console.log('Unique id test passed');


### PR DESCRIPTION
## Summary
- add a new package-size test to report bundle size
- run compilation and tests via npm script
- update existing tests with explicit linter options
- document how to run tests in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848934c5ab88331ab7fa6c3c8b2133f