### PR TITLE
Improve main tag linting

### DIFF
--- a/src/component-analyzer.ts
+++ b/src/component-analyzer.ts
@@ -33,6 +33,8 @@ interface ComponentDefinition {
   issues: Map<string, LintResult[]>;
   usesComponents: ComponentReference[];
   headings: HeadingInfo[];
+  hasMain: boolean;
+  aliasOf: string | null;
 }
 
 export class ComponentAnalyzer {
@@ -65,11 +67,14 @@ export class ComponentAnalyzer {
       filePath,
       issues: new Map(),
       usesComponents: [],
-      headings: []
+      headings: [],
+      hasMain: false,
+      aliasOf: null
     };
 
     // Track imported components
     const importedComponents = new Map<string, string>();
+    let reExportPath: string | null = null;
     
     // Collect imports and JSX usages
     traverse(ast, {
@@ -84,12 +89,31 @@ export class ComponentAnalyzer {
           }
         });
       },
+      ExportNamedDeclaration(path) {
+        if (path.node.source) {
+          const hasDefault = path.node.specifiers.some(s => {
+            const exp: any = (s as any).exported;
+            return exp && exp.name === 'default';
+          });
+          if (hasDefault || path.node.specifiers.length === 0) {
+            reExportPath = path.node.source.value as string;
+          }
+        }
+      },
+      ExportAllDeclaration(path) {
+        if (path.node.source) {
+          reExportPath = path.node.source.value as string;
+        }
+      },
       JSXElement(path) {
         const elt = path.node.openingElement.name;
         if (t.isJSXIdentifier(elt)) {
           const name = elt.name;
-          // Record headings
           const tag = name.toLowerCase();
+          if (tag === 'main') {
+            componentDef.hasMain = true;
+          }
+          // Record headings
           if (/^h[1-6]$/.test(tag)) {
             const level = parseInt(tag.charAt(1), 10);
             const loc = elt.loc?.start;
@@ -136,6 +160,10 @@ export class ComponentAnalyzer {
       if (ref.rawImportPath) {
         ref.path = await this.resolveComponentPath(ref.rawImportPath, filePath);
       }
+    }
+
+    if (reExportPath) {
+      componentDef.aliasOf = await this.resolveComponentPath(reExportPath, filePath);
     }
 
     // Check for heading order issues within this component
@@ -241,6 +269,7 @@ export class ComponentAnalyzer {
 
     if (rules.singleH1) this.findCrossComponentH1Issues(results);
     if (rules.enforceHeadingOrder) this.findCrossComponentHeadingOrderIssues(results);
+    if (rules.requireMain) this.findCrossComponentMainIssues(results);
 
     return results;
   }
@@ -439,6 +468,46 @@ export class ComponentAnalyzer {
     }
     
     return allHeadings;
+  }
+
+  private componentTreeHasMain(component: ComponentDefinition, visited = new Set<string>()): boolean {
+    if (visited.has(component.filePath)) return false;
+    visited.add(component.filePath);
+    if (component.hasMain) return true;
+
+    if (component.aliasOf) {
+      if (this.componentRegistry.has(component.aliasOf)) {
+        if (this.componentTreeHasMain(this.componentRegistry.get(component.aliasOf)!, visited)) {
+          return true;
+        }
+      } else {
+        // Assume external component may contain <main>
+        return true;
+      }
+    }
+    for (const ref of component.usesComponents) {
+      if (ref.path && this.componentRegistry.has(ref.path)) {
+        if (this.componentTreeHasMain(this.componentRegistry.get(ref.path)!, visited)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private findCrossComponentMainIssues(results: LintResult[]): void {
+    const entryPoints = this.findEntryPoints();
+    for (const entry of entryPoints) {
+      if (!this.componentTreeHasMain(entry)) {
+        results.push({
+          filePath: entry.filePath,
+          line: 0,
+          column: 0,
+          message: 'Document missing <main> element',
+          rule: 'requireMain'
+        });
+      }
+    }
   }
 
   private findEntryPoints(): ComponentDefinition[] {


### PR DESCRIPTION
## Summary
- filter `requireMain` warnings from non-entry components
- detect `<main>` usage inside component analyzer
- report missing `<main>` only at entry points
- treat re-export pages as aliases
- ignore files in `node_modules`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848a3c85e4083318a9f08c43ffe85f1