### PR TITLE
Add performance diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
           "default": true,
           "description": "Analyze and detect semantic issues across component boundaries"
         },
+        "zemdomu.devMode": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable developer diagnostics and performance output."
+        },
         "zemdomu.rules.requireSectionHeading": {
           "type": "boolean",
           "default": true,

--- a/src/performance-diagnostics.ts
+++ b/src/performance-diagnostics.ts
@@ -1,0 +1,66 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+export class PerformanceDiagnostics {
+  private channel = vscode.window.createOutputChannel('ZemDomu Perf');
+  private devMode: boolean;
+  private pending = new Map<string, string>();
+
+  constructor(devMode: boolean) {
+    this.devMode = devMode;
+  }
+
+  updateDevMode(devMode: boolean) {
+    this.devMode = devMode;
+  }
+
+  record(filePath: string, timings: Record<string, number>) {
+    const msg = `${path.basename(filePath)} => ` +
+      Object.entries(timings)
+        .map(([k, v]) => `${k}:${v.toFixed(2)}ms`)
+        .join(' | ');
+    this.channel.appendLine(msg);
+    if (this.devMode) {
+      this.pending.set(filePath, msg);
+    }
+  }
+
+  applyDiagnostics(uri: vscode.Uri, diags: vscode.Diagnostic[]) {
+    if (this.devMode && this.pending.has(uri.fsPath)) {
+      const msg = this.pending.get(uri.fsPath)!;
+      const diag = new vscode.Diagnostic(
+        new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)),
+        msg,
+        vscode.DiagnosticSeverity.Information
+      );
+      diag.source = 'ZemDomu Perf';
+      diags.push(diag);
+      this.pending.delete(uri.fsPath);
+    }
+  }
+
+  async reportBundleSize(root: string): Promise<void> {
+    const dist = path.join(root, 'dist', 'extension.js');
+    const out = path.join(root, 'out', 'extension.js');
+    let target = '';
+    try {
+      await fs.stat(dist);
+      target = dist;
+    } catch {
+      try {
+        await fs.stat(out);
+        target = out;
+      } catch {
+        return;
+      }
+    }
+    try {
+      const size = (await fs.stat(target)).size;
+      const kb = (size / 1024).toFixed(2);
+      this.channel.appendLine(`Bundle size (${path.basename(target)}): ${kb} KB`);
+    } catch {
+      // ignore
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- support developer-only performance diagnostics
- time analyzer phases and report results
- expose a new `zemdomu.devMode` setting
- pipe timing info into diagnostics when developer mode is enabled

## Testing
- `npm test`
- `npm run compile`
- `npm run bundle`


------
https://chatgpt.com/codex/tasks/task_e_684fd1670c948331955faaef7347faf0