### PR TITLE
Optimize resolvePaths performance

### DIFF
--- a/src/component-analyzer.ts
+++ b/src/component-analyzer.ts
@@ -155,7 +155,9 @@ export class ComponentAnalyzer {
     t0 = Date.now();
     for (const ref of componentDef.usesComponents) {
       if (ref.rawImportPath) {
+        const t1 = Date.now();
         ref.path = await this.resolveComponentPath(ref.rawImportPath, filePath);
+        timings[`resolve:${ref.rawImportPath}`] = Date.now() - t1;
       }
     }
     timings.resolvePaths = Date.now() - t0;

--- a/src/component-path-resolver.ts
+++ b/src/component-path-resolver.ts
@@ -4,6 +4,16 @@ import * as path from 'path';
 export class ComponentPathResolver {
   private static resolveCache = new Map<string, string | null>();
   private static statCache = new Map<string, boolean>();
+  private static aliasCache = new Map<string, Map<string, string>>();
+  private static unresolved = new Set<string>();
+
+  private static normalizeKey(p: string): string {
+    return p
+      .replace(/\\/g, '/')
+      .replace(/\/+$/, '')
+      .replace(/\.(tsx|ts|jsx|js)$/, '')
+      .toLowerCase();
+  }
 
   private async fileExists(p: string): Promise<boolean> {
     if (ComponentPathResolver.statCache.has(p)) {
@@ -20,9 +30,11 @@ export class ComponentPathResolver {
   }
 
   async resolve(importPath: string, currentPath: string): Promise<string | null> {
-    const key = importPath.startsWith('.')
+    const rawKey = importPath.startsWith('.')
       ? path.resolve(path.dirname(currentPath), importPath)
       : importPath;
+    const key = ComponentPathResolver.normalizeKey(rawKey);
+    if (ComponentPathResolver.unresolved.has(key)) return null;
     if (ComponentPathResolver.resolveCache.has(key)) {
       return ComponentPathResolver.resolveCache.get(key)!;
     }
@@ -48,24 +60,50 @@ export class ComponentPathResolver {
           if (!result) result = base;
         }
       } else {
-        const patterns = [
-          `**/${importPath}.{tsx,jsx,ts,js}`,
-          `**/${importPath}/index.{tsx,jsx,ts,js}`
-        ];
-        for (const ptn of patterns) {
-          const pKey = `glob:${ptn}`;
-          if (ComponentPathResolver.resolveCache.has(pKey)) {
-            const cached = ComponentPathResolver.resolveCache.get(pKey)!;
-            if (cached) { result = cached; break; }
-            continue;
+        const prefix = importPath.split('/')[0];
+        let alias = ComponentPathResolver.aliasCache.get(prefix);
+        if (!alias) {
+          const pattern = `**/${prefix}/**/*.{tsx,jsx,ts,js}`;
+          const files = await vscode.workspace.findFiles(pattern, '**/node_modules/**', 200);
+          alias = new Map();
+          for (const uri of files) {
+            const rel = uri.fsPath.replace(/\\/g, '/');
+            const idx = rel.lastIndexOf(`/${prefix}/`);
+            if (idx === -1) continue;
+            const after = rel.substring(idx + prefix.length + 2).replace(/\.(tsx|ts|jsx|js)$/, '');
+            const key1 = ComponentPathResolver.normalizeKey(`${prefix}/${after}`);
+            alias.set(key1, uri.fsPath);
+            if (after.endsWith('/index')) {
+              const trimmed = after.replace(/\/index$/, '');
+              alias.set(ComponentPathResolver.normalizeKey(`${prefix}/${trimmed}`), uri.fsPath);
+            }
           }
-          const matches = await vscode.workspace.findFiles(ptn, null, 1);
-          if (matches.length) {
-            result = matches[0].fsPath;
-            ComponentPathResolver.resolveCache.set(pKey, result);
-            break;
-          } else {
-            ComponentPathResolver.resolveCache.set(pKey, null);
+          ComponentPathResolver.aliasCache.set(prefix, alias);
+        }
+
+        const normImport = ComponentPathResolver.normalizeKey(importPath);
+        result = alias.get(normImport) || null;
+
+        if (!result) {
+          const patterns = [
+            `**/${importPath}.{tsx,jsx,ts,js}`,
+            `**/${importPath}/index.{tsx,jsx,ts,js}`
+          ];
+          for (const ptn of patterns) {
+            const pKey = `glob:${ptn}`;
+            if (ComponentPathResolver.resolveCache.has(pKey)) {
+              const cached = ComponentPathResolver.resolveCache.get(pKey)!;
+              if (cached) { result = cached; break; }
+              continue;
+            }
+            const matches = await vscode.workspace.findFiles(ptn, '**/node_modules/**', 1);
+            if (matches.length) {
+              result = matches[0].fsPath;
+              ComponentPathResolver.resolveCache.set(pKey, result);
+              break;
+            } else {
+              ComponentPathResolver.resolveCache.set(pKey, null);
+            }
           }
         }
       }
@@ -73,6 +111,7 @@ export class ComponentPathResolver {
       result = null;
     }
     ComponentPathResolver.resolveCache.set(key, result);
+    if (result === null) ComponentPathResolver.unresolved.add(key);
     return result;
   }
 }


### PR DESCRIPTION
## Summary
- improve caching in `ComponentPathResolver`
- batch glob lookups by alias and skip previously unresolved imports
- track individual import resolution times

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fe11fec2c8331abc75b3635199a8b